### PR TITLE
feat: push to ansible galaxy and container registry if tagges

### DIFF
--- a/.github/workflows/build-collection.yaml
+++ b/.github/workflows/build-collection.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       repo_tag: ${{ steps.repo_tag.outputs.repo_tag }}
+      push: ${{ steps.repo_tag.outputs.push }}
       dev_tag: ${{ env.dev_tag }}
     steps:
       - name: Checkout code
@@ -27,6 +28,7 @@ jobs:
 
           # Precompute latest tag (if any)
           tag_name=$(git tag --sort=-v:refname | head -n 1)
+          echo "push=false" >> $GITHUB_OUTPUT
 
           if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "pull_request" ]]; then
             if [[ -z "$tag_name" ]]; then
@@ -39,11 +41,13 @@ jobs:
             if [[ "${{ github.ref }}" == refs/tags/* ]]; then
               # Extract tag name from ref (e.g., refs/tags/v1.0.0 -> v1.0.0)
               echo "repo_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+              echo "push=true" >> $GITHUB_OUTPUT
             elif [[ -z "$tag_name" ]]; then
               echo "No tags found in the repository."
               echo "repo_tag=${{ env.dev_tag }}" >> $GITHUB_OUTPUT
             else
               echo "repo_tag=$tag_name" >> $GITHUB_OUTPUT
+              echo "push=true" >> $GITHUB_OUTPUT
             fi
           fi
 
@@ -55,7 +59,7 @@ jobs:
     needs: tag-lookup
     with:
       path: .
-      push: false
+      push: ${{ needs.tag-lookup.outputs.push }}
       version: ${{ needs.tag-lookup.outputs.repo_tag }}
     secrets:
       galaxy_token: ${{ secrets.ANSIBLE_GALAXY_TOKEN }}
@@ -69,7 +73,7 @@ jobs:
       - ansible-build-collection
     uses: ./.github/workflows/build-ee.yaml
     with:
-      push: false
+      push: ${{ needs.tag-lookup.outputs.push }}
       upload_execution_environment: ${{ needs.tag-lookup.outputs.repo_tag == needs.tag-lookup.outputs.dev_tag }}
       version: ${{ needs.tag-lookup.outputs.repo_tag }}
       download_artifact: ${{ needs.tag-lookup.outputs.repo_tag == needs.tag-lookup.outputs.dev_tag }}


### PR DESCRIPTION
In previous iterations, neither the collection nor the execution environment (EE) was uploaded to an upstream registry