### PR TITLE
feat: build execution environment once a week

### DIFF
--- a/.github/workflows/build-weekly-ee.yaml
+++ b/.github/workflows/build-weekly-ee.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       repo_tag: ${{ steps.get_tag.outputs.repo_tag }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5


### PR DESCRIPTION
# Description

With this new GitHub CI workflow action, we automatically rebuild the execution environment image once a week. This allows us to ensure that the latest binaries and versions are always included in the execution environment.
