### PR TITLE
fix(bootstrap_gitops): type definition for ha.enabled value

### DIFF
--- a/roles/bootstrap_gitops/templates/argocd-instance.yaml.j2
+++ b/roles/bootstrap_gitops/templates/argocd-instance.yaml.j2
@@ -21,7 +21,7 @@ spec:
     route:
       enabled: false
   ha:
-    enabled: "{{ argocd.instance.ha_enabled }}"
+    enabled: {{ argocd.instance.ha_enabled }}
   initialSSHKnownHosts: {}
   kustomizeBuildOptions: --enable-alpha-plugins --enable-helm
   monitoring:


### PR DESCRIPTION
# Description

In previous versions, when OpenShift GitOps was deployed using our provided role, the role repeatedly raised an issue requiring a boolean value for the `argocd.instance.ha_enabled` key. This occurred even when the key was already set to a valid boolean. The root cause was that the role incorrectly quoted the user-provided input, causing the validation to fail.