### PR TITLE
feat: enable fact caching

### DIFF
--- a/roles/add_nodes/tasks/main.yaml
+++ b/roles/add_nodes/tasks/main.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Set facts for manifest generation
   ansible.builtin.set_fact:
+    cacheable: yes
     manifest_folder: "{{ base_dir }}/manifests"
     credentials_folder: "{{ base_dir }}/credentials"
     iso_location: "{{ base_dir }}/agent.iso"

--- a/roles/bootstrap_cluster/tasks/main.yaml
+++ b/roles/bootstrap_cluster/tasks/main.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Set bootstrap facts
   ansible.builtin.set_fact:
+    cacheable: yes
     cluster_name: "{{ cluster_name }}"
     base_domain: "{{ base_domain }}"
     cluster_domain: "{{ cluster_name }}.{{ base_domain }}"


### PR DESCRIPTION
# Description

## Summary

As part of the role, we previously defined facts that we used within the role. With the setting “cacheable: yes,” we want to ensure that facts can be used outside of the role.

## Component Affected

Specify which part of the Ansible Collection is affected:

- [x] Roles

## Checklist

Please confirm you have completed the following:

- [x] I have tested these changes locally.
- [x] I verified that all new or modified YAML files pass linting (`ansible-lint` / `yamllint`).
- [ ] I verified molecule tests (if applicable) pass successfully.
- [x] I updated or added documentation where necessary.
- [x] I updated or added examples where necessary.
- [x] I added or updated tests where appropriate.
