### PR TITLE
feat(bootstrap_cluster): user managed load balancer for bare metal clusters

### DIFF
--- a/roles/bootstrap_cluster/README.md
+++ b/roles/bootstrap_cluster/README.md
@@ -17,6 +17,9 @@ cluster_name: "my-cluster"
 # baremetal should be used for OpenShift clusters that are installed on bare metal (default).
 type: baremetal
 
+# lb_type defines the type of load balancer to be used for the cluster. Valid values are "UserManaged" or "". If set to "UserManaged", the OpenShift cluster is expected to run behind a user-provided load balancer. If set to "", the Keepalived load balancer will be used for the cluster. The Keepalived load balancer is only supported for bare metal installations. If the installation type is set to "none", lb_type will be ignored and the Keepalived load balancer will not be used, regardless of the value of lb_type.
+lb_type: ""
+
 # boot_artifacts_base_url is optional, if not provided, it will not be included in the agent-config.yaml
 # boot_artifacts_base_url: "http://example.com/boot-artifacts"
 

--- a/roles/bootstrap_cluster/_tests/fact-check/vars.yaml
+++ b/roles/bootstrap_cluster/_tests/fact-check/vars.yaml
@@ -1,6 +1,7 @@
 tenant_name: test-tenant
 cluster_name: ocp4-test
 base_domain: example.com
+lb_type: UserManaged
 
 api_vip: 10.10.10.4
 ingress_vip: 10.10.10.5

--- a/roles/bootstrap_cluster/templates/install-config.yaml.j2
+++ b/roles/bootstrap_cluster/templates/install-config.yaml.j2
@@ -34,6 +34,10 @@ sshKey: |
 platform:
 {% if type == "baremetal" %}
   baremetal:
+{% if (lb_type | default("")) == "UserManaged"  %}
+    loadBalancer:
+      type: UserManaged
+{% endif %}
     apiVIP: {{ api_vip }}
     ingressVIP: {{ ingress_vip }}
 {% else %}


### PR DESCRIPTION
# Description

## Summary

Implements support for leveraging existing Load Balancer infrastructure in bare metal installations. With this approach, the Keepalived component no longer manages VIP allocation for ingress and the API server, and instead assumes that the configured IP addresses already route to the external Load Balancer.

## Related Issues

Link any relevant issues, e.g.:

- Closes #79

## Component Affected

Specify which part of the Ansible Collection is affected:

- [x] Roles
- [ ] Playbooks
- [ ] Modules / Plugins
- [x] Documentation
- [x] Tests
- [ ] Other (describe):

## Checklist

Please confirm you have completed the following:

- [x] I have tested these changes locally.
- [x] I verified that all new or modified YAML files pass linting (`ansible-lint` / `yamllint`).
- [ ] I verified molecule tests (if applicable) pass successfully.
- [x] I updated or added documentation where necessary.
- [x] I updated or added examples where necessary.
- [ ] I added or updated tests where appropriate.
